### PR TITLE
Use certificate_name instead of certificate_id in LB forwarding rules

### DIFF
--- a/01-minimal-web-db-stack/web-servers.tf
+++ b/01-minimal-web-db-stack/web-servers.tf
@@ -106,7 +106,7 @@ resource "digitalocean_loadbalancer" "web" {
         target_port = 80
         target_protocol = "http"
 
-        certificate_id = digitalocean_certificate.web.id
+        certificate_name = "${var.name}-certificate"
     }
 
     forwarding_rule {
@@ -116,7 +116,7 @@ resource "digitalocean_loadbalancer" "web" {
         target_port = 80
         target_protocol = "http"
 
-        certificate_id = digitalocean_certificate.web.id
+        certificate_name = "${var.name}-certificate"
     }
 
     #-----------------------------------------------------------------------------------------------#


### PR DESCRIPTION
According to [terraform docs on DO loadbalancers](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/loadbalancer) the certificate_id field is deprecated.

Since the certificate_id also changes when the cert is rotated, using certificate_name seems to be a more sensible approach.