### PR TITLE
Added security values to outputs

### DIFF
--- a/01-minimal-web-db-stack/outputs.tf
+++ b/01-minimal-web-db-stack/outputs.tf
@@ -21,6 +21,7 @@ output "database_port" {
 # The URI for connecting to the database
 output "database_private_uri" {
     value = digitalocean_database_cluster.postgres-cluster.private_uri
+    sensitive = true
 }
 
 # The name of the default database
@@ -36,4 +37,5 @@ output "database_user" {
 # The default user password
 output "database_password" {
     value = digitalocean_database_cluster.postgres-cluster.password
+    sensitive = true
 }


### PR DESCRIPTION
Because Terraform has been updated, I've updated the `outputs.tf` file with the `sensitive = true` fields where applicable. Without these fields, the architecture in the Terraform Deploy tutorial does not deploy without the user needing to edit that file manually. 

I've tested this with the new values and it works.