### PR TITLE
Fixed broken (outdated) resources

### DIFF
--- a/01-minimal-web-db-stack/database.tf
+++ b/01-minimal-web-db-stack/database.tf
@@ -10,8 +10,8 @@ resource "digitalocean_database_cluster" "postgres-cluster" {
     # The database engine to use. Currently Postgres. Could be MySql or Redis
     engine     = "pg"
 
-    # Version of the engine. So Postgres 11
-    version    = "11"
+    # Version of the engine. So Postgres 17
+    version    = "17"
 
     # Size of the database instance
     size       = var.database_size

--- a/01-minimal-web-db-stack/variables.tf
+++ b/01-minimal-web-db-stack/variables.tf
@@ -67,5 +67,5 @@ variable "database_size" {
 # Can view slugs (valid options) https://slugs.do-api.dev/
 variable "image" {
     type = string
-    default = "ubuntu-20-04-x64"
+    default = "ubuntu-24-04-x64"
 }


### PR DESCRIPTION
I was going through the tutorial [Deploy A Sample Web Application on DigitalOcean Using Terraform](https://docs.digitalocean.com/reference/terraform/deploy-web-app/) today (August 3, 2025) and some errors popped up due to outdated versions of the Ubuntu image and of PostgreSQL being used.

I've updated the aforementioned resource definitions so the tutorial works as intended again.

For reference, these were the errors I experienced:
```
│ Error: Error creating droplet: POST https://api.digitalocean.com/v2/droplets: 422 (request "0d5556c2-f9e5-4fd0-a657-0a22aa14f9d6") You specified an invalid image for Droplet creation.
│ 
│   with digitalocean_droplet.bastion,
│   on bastions.tf line 4, in resource "digitalocean_droplet" "bastion":
│    4: resource "digitalocean_droplet" "bastion" {
│ 
╵
╷
│ Error: Error creating database cluster: POST https://api.digitalocean.com/v2/databases: 422 (request "ac88e07b-dcaf-48f7-aaa2-ca76b58afcf0") invalid cluster engine version
│ 
│   with digitalocean_database_cluster.postgres-cluster,
│   on database.tf line 5, in resource "digitalocean_database_cluster" "postgres-cluster":
│    5: resource "digitalocean_database_cluster" "postgres-cluster" {
│ 
╵
```